### PR TITLE
fix: removed memory limit flag on start script in package.json, not n…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "jest",
     "server": "nodemon index.js",
-    "start": "node -–max-old-space-size=2048 index.js"
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…eeded now that we are not using the zip library and potentially causing heroku errors