### PR TITLE
fix: remedied 404 error triggered by out-of-USA requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,7 @@ app.get("/", (req, res) => {
 
 // app listens on the decided port of the team/environment
 app.listen(PORT, () => {
-  console.log(`Listening on port ${PORT}...`, function(err) {
-    console.log(err)
-  });
+  console.log(`Listening on port ${PORT}...`);
 });
 
 module.exports = app;

--- a/util/generateSMS.js
+++ b/util/generateSMS.js
@@ -3,19 +3,17 @@
 if (process.env.NODE_ENV !== "production") {
   require("dotenv").config({ path: '../.env' });
 }
-// authenticated twilio import
-const client = require("twilio")(process.env.ACCOUNT_SID, process.env.AUTH_TOKEN);
 
 // util function
 const upOrDown = require('./upOrDown.js');
 
 // function that generates appropriate message SMS message depending on the success/error case
-function generateSMS(status, countyInfo, covidData) {
+function generateSMS(status, countyInfo) {
   // defining var to store appropriate message body
   let messageBody;
 
   // if all these cases are true, create success message body
-  if (status === "SUCCESS" && typeof countyInfo !== "undefined" && covidData !== "undefined") {
+  if (status === "SUCCESS" && typeof countyInfo !== "undefined") {
 
     // still need to find a better way to format template literals besides shift + tabbing them to beginning of line
     messageBody =`


### PR DESCRIPTION
Added return statement in if block that checksfor valid but out of country numbers.  It was
previously throwing a 404, now handled
appropriately.

Also switched message sending technique back to the client.messages.create().

Removed a few unnecessary  imports