### PR TITLE
fix: fixed broken NYC zip codes

### DIFF
--- a/routes/sms-routes.js
+++ b/routes/sms-routes.js
@@ -174,7 +174,7 @@ router.post("/", async (req, res) => {
         body: smsMessage,
         to: phoneNumber,
       })
-      .then((message) => console.log(message))
+      .then((message) => console.log('ok'))
       .catch((err) => console.log(err));
 
     // setting headers for response to twilio

--- a/util/generateSMS.js
+++ b/util/generateSMS.js
@@ -17,7 +17,7 @@ function generateSMS(status, countyInfo, userObj) {
 
     // still need to find a better way to format template literals besides shift + tabbing them to beginning of line
     messageBody = `
-${countyInfo.county_name} County, ${countyInfo.state_name} 🇺🇸
+${countyInfo.county_name} ${countyInfo.county_name.includes("New York") ? "City" : "County"}, ${countyInfo.state_name} 🇺🇸
 
 Today's Report: 
 - Confirmed Cases: ${upOrDown(countyInfo.new)} ${countyInfo.new}

--- a/util/getCountyFromPostalCode.js
+++ b/util/getCountyFromPostalCode.js
@@ -11,12 +11,19 @@ const generateSMS = require('./generateSMS.js');
 async function getCountyFromPostalCode(postalCode) {
   // defining message body
   let badInputMessage = '';
-
+  let locationInfo;
+  console.log(postalCode)
   // initial declaration of county and state variables
   let geoData = await axios.get(`https://api.opencagedata.com/geocode/v1/google-v3-json?q=countrycode=us|postcode=${postalCode}&key=${process.env.GEOCODING_KEY}&limit=1`)
-  
+  console.log('data from geocode', geoData.data.results[0])
+  // console.log('types', geoData.data.results[0].address_components[])
   // checking if provided zipcode is valid or not
-  if (!geoData.data.results[0] && toPhoneNumber !== "undefined") {
+  if (geoData.data.results[0].formatted_address.includes("New York, NY")) {
+    locationInfo = {
+      state: "NY",
+      county: "New York"
+    }
+  } else if (!geoData.data.results[0] && toPhoneNumber !== "undefined") {
     badInputMessage = generateSMS("BAD_INPUT");
 
   } else {
@@ -27,13 +34,13 @@ async function getCountyFromPostalCode(postalCode) {
     countyArray.pop();
     county = countyArray.join(' ');
     
-    let locationInfo = {
-      state: state,
-      county: county,
+    locationInfo = {
+      state: state, // ex. CA
+      county: county, // ex. Los Angeles
     };
   
-    return { 'locationInfo': locationInfo, 'badInputMessage': badInputMessage }
   }
+  return { 'locationInfo': locationInfo, 'badInputMessage': badInputMessage }
 }
 
 module.exports = getCountyFromPostalCode;


### PR DESCRIPTION
- Added extra if statement to check if the county in NY, manually setting locationInfo object if so
- Instantiated locationInfo at top of function instead of in the else block
- Added ternary in template literal success message to replace "County" with "City" if it is a NYC zip

# Description

What Changed ? e.g. Github Issues Title or Trello Card Title

**Please describe it here... in EDIT mode.**
Added in logic to handle the New York City ZIP codes that were returned from geocoding API in a different format than everything else.

## Type of change

**Please don't put a X mark here in EDIT mode**

- [ ] :recycle: :wastebasket: Re-factor, cleanup, un-comment, docstring
- [ ] :ambulance: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkles: New feature (non-breaking change which adds functionality)
- [x] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change Status

**Please don't put a X mark here in EDIT mode**

- [ ] :checkered_flag: Complete, tested, ready to review and merge
- [x] :traffic_light: Complete, but not tested (may need new tests)
- [ ] :construction: WIP work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

**Please don't put a X mark here in EDIT mode**

- [x] Manually Functionality Testing
- [ ] Unit Test

# Checklist

**Please don't put a X mark here in EDIT mode**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts